### PR TITLE
Add stack filter by endpointID

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37553,7 +37553,10 @@ const Portainer = __nccwpck_require__(1055)
         // Get Stack
         const stacks = await portainer.getStacks()
         // console.log('stacks:', stacks)
-        let stack = stacks.find((item) => item.Name === config.name)
+        let stack = stacks.find(
+            (item) =>
+                item.Name === config.name && item.EndpointId === endpointID
+        )
         // console.log('stack:', stack)
         let stackID = stack?.Id
         core.info(`stackID: \u001b[36m${stackID}`)

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,10 @@ const Portainer = require('./portainer')
         // Get Stack
         const stacks = await portainer.getStacks()
         // console.log('stacks:', stacks)
-        let stack = stacks.find((item) => item.Name === config.name && item.EndpointId === endpointID)
+        let stack = stacks.find(
+            (item) =>
+                item.Name === config.name && item.EndpointId === endpointID
+        )
         // console.log('stack:', stack)
         let stackID = stack?.Id
         core.info(`stackID: \u001b[36m${stackID}`)

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ const Portainer = require('./portainer')
         // Get Stack
         const stacks = await portainer.getStacks()
         // console.log('stacks:', stacks)
-        let stack = stacks.find((item) => item.Name === config.name)
+        let stack = stacks.find((item) => item.Name === config.name && item.EndpointId === endpointID)
         // console.log('stack:', stack)
         let stackID = stack?.Id
         core.info(`stackID: \u001b[36m${stackID}`)


### PR DESCRIPTION
# Overview

Currently the stack filter is not considering EndpointID. Because of that, two stacks with the same name are migrated between one environment and another, instead of creating a new one.

## Checklist
<!-- Do NOT remove tasks and append any custom tasks -->
- [X] Verify the Required Checks are Passing
- [X] Document changes in the [README.md](../blob/master/README.md) (for new features)